### PR TITLE
feat: upstream common patterns

### DIFF
--- a/ksm-custom/crossplane.libsonnet
+++ b/ksm-custom/crossplane.libsonnet
@@ -7,6 +7,25 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
   '#':: d.package.newSub('crossplane', 'Helper functions related to Crossplane'),
 
+  '#fromGroupVersionKinds':: d.fn(
+    'Generate a new CustomResourceStateMetrics object from an array of GroupVersionKind tuples.',
+    args=[
+      d.arg('gvks', d.T.array),
+    ],
+  ),
+  fromGroupVersionKinds(gvks):
+    local sorted =
+      std.sort(
+        gvks,
+        function(obj) '%(group)s#%(version)s#%(kind)s' % obj
+      );
+
+    ksmCustom.new()
+    + ksmCustom.spec.withResources([
+      self.statusResource(gvk.group, gvk.version, gvk.kind)
+      for gvk in sorted
+    ]),
+
   '#statusResource':: d.fn(
     |||
       This is a first attempt at gathering metrics for Crossplane resources using


### PR DESCRIPTION
- **feat(util): handle group/plural tuples**

A common pattern I found was generating GroupVersionKind tuples for the ksm-custom Crossplane statusResource function. This'll allow us to add a `plural` key to the tuple data.

- **feat(ksm-custom/crossplane): add helper function**

A common pattern to create a CustomResourceStateMetrics from GroupVersionKind tuples.