### PR TITLE
feat(kube-state-metrics): add function to scrape ServiceAccount metrics

### DIFF
--- a/kube-state-metrics/docs/README.md
+++ b/kube-state-metrics/docs/README.md
@@ -35,6 +35,7 @@ local kubeStateMetrics = import "github.com/crdsonnet/kube-state-metrics-libsonn
 * [`fn withPolicyRulesMixin(rules)`](#fn-withpolicyrulesmixin)
 * [`fn withPriorityClass(priorityClassName)`](#fn-withpriorityclass)
 * [`fn withReplicas(replicas)`](#fn-withreplicas)
+* [`fn withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=["*"], labelsAllowList=["*"])`](#fn-withserviceaccountmetrics)
 
 ## Fields
 
@@ -213,3 +214,22 @@ PARAMETERS:
 * **replicas** (`number`)
 
 `withReplicas` sets the replicas, only applies to automatic sharding.
+
+### fn withServiceAccountMetrics
+
+```jsonnet
+withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=["*"], labelsAllowList=["*"])
+```
+
+PARAMETERS:
+
+* **metrics** (`array`)
+   - default value: `["kube_serviceaccount_info"]`
+* **annotationsAllowList** (`array`)
+   - default value: `["*"]`
+* **labelsAllowList** (`array`)
+   - default value: `["*"]`
+
+`withServiceAccountMetrics` enables scraping [ServiceAccount metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/auth/serviceaccount-metrics.md).
+
+`annotationsAllowList` and `labelsAllowList` is only applied along with respective `metrics`.

--- a/kube-state-metrics/docs/README.md
+++ b/kube-state-metrics/docs/README.md
@@ -35,7 +35,7 @@ local kubeStateMetrics = import "github.com/crdsonnet/kube-state-metrics-libsonn
 * [`fn withPolicyRulesMixin(rules)`](#fn-withpolicyrulesmixin)
 * [`fn withPriorityClass(priorityClassName)`](#fn-withpriorityclass)
 * [`fn withReplicas(replicas)`](#fn-withreplicas)
-* [`fn withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=["*"], labelsAllowList=["*"])`](#fn-withserviceaccountmetrics)
+* [`fn withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=[], labelsAllowList=[])`](#fn-withserviceaccountmetrics)
 
 ## Fields
 
@@ -218,7 +218,7 @@ PARAMETERS:
 ### fn withServiceAccountMetrics
 
 ```jsonnet
-withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=["*"], labelsAllowList=["*"])
+withServiceAccountMetrics(metrics=["kube_serviceaccount_info"], annotationsAllowList=[], labelsAllowList=[])
 ```
 
 PARAMETERS:
@@ -226,10 +226,8 @@ PARAMETERS:
 * **metrics** (`array`)
    - default value: `["kube_serviceaccount_info"]`
 * **annotationsAllowList** (`array`)
-   - default value: `["*"]`
+   - default value: `[]`
 * **labelsAllowList** (`array`)
-   - default value: `["*"]`
+   - default value: `[]`
 
 `withServiceAccountMetrics` enables scraping [ServiceAccount metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/auth/serviceaccount-metrics.md).
-
-`annotationsAllowList` and `labelsAllowList` is only applied along with respective `metrics`.

--- a/kube-state-metrics/docs/utils.md
+++ b/kube-state-metrics/docs/utils.md
@@ -5,6 +5,7 @@ Helper functions to use in combination with kube-state-metrics
 ## Index
 
 * [`fn createWatchRules(groupResources)`](#fn-createwatchrules)
+* [`fn getResourcesFromRules(rules)`](#fn-getresourcesfromrules)
 * [`fn scrapeConfig(namespace, name="kube-state-metrics")`](#fn-scrapeconfig)
 * [`fn sortRules(rules)`](#fn-sortrules)
 
@@ -57,6 +58,17 @@ Will result in these policyRules:
 Additionally the policy rules array will be sorted so that the order of the
 input array does not affect the output order.
 
+### fn getResourcesFromRules
+
+```jsonnet
+getResourcesFromRules(rules)
+```
+
+PARAMETERS:
+
+* **rules** (`array`)
+
+`getResourcesFromRules` returns an array of resources for the given policy rules.
 ### fn scrapeConfig
 
 ```jsonnet

--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -3,6 +3,8 @@ local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet'
 local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
 {
+  local root = self,
+
   '#':: d.package.new(
     'kubeStateMetrics',
     help=|||
@@ -34,10 +36,18 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   ):: {
         local this = self,
         name:: name,
+
+        local defaultResources = utils.getResources(root.withKubernetesWatchPolicyRules().policyRules),
+        local resources = utils.getResources(this.policyRules),
         config:: {
           port: 8080,
           telemetry_host: '0.0.0.0',
           telemetry_port: 8081,
+          // Only include 'resources' when different from the default set
+          [if resources != defaultResources then 'resources']: {
+            [resource]: {}
+            for resource in resources
+          },
         },
         config_file:: 'config.yml',
         config_path:: '/etc/kube-state-metrics',
@@ -347,6 +357,41 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
     self.withPolicyRulesMixin(utils.createWatchRules(definitions)),
 
+
+  '#withServiceAccountMetrics':: d.fn(
+    |||
+      `withServiceAccountMetrics` enables scraping [ServiceAccount metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/auth/serviceaccount-metrics.md).
+
+      `annotationsAllowList` and `labelsAllowList` is only applied along with respective `metrics`.
+    |||,
+    args=[
+      d.arg('metrics', d.T.array, default=['kube_serviceaccount_info']),
+      d.arg('annotationsAllowList', d.T.array, default=['*']),
+      d.arg('labelsAllowList', d.T.array, default=['*']),
+    ]
+  ),
+  withServiceAccountMetrics(
+    metrics=['kube_serviceaccount_info'],
+    annotations=['*'],
+    labels=['*'],
+  )::
+    self.withPolicyRulesMixin(
+      utils.createWatchRules([{
+        group: '',
+        resources: ['serviceaccounts'],
+      }])
+    )
+    + {
+      config+:: {
+        metric_opt_in_list+: {
+          [metric]: {}
+          for metric in metrics
+        },
+        [if std.member(metrics, 'kube_serviceaccount_annotations') then 'annotations_allow_list']+: annotations,
+        [if std.member(metrics, 'kube_serviceaccount_labels') then 'labels_allow_list']+: labels,
+      },
+    },
+
   '#withKubeRBACProxyPolicyRules':: d.fn(
     |||
       `withKubeRBACProxyPolicyRules` configures an additional policy rule for
@@ -415,5 +460,5 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       deployment.configMapVolumeMount(self.CRSMConfigMap, '/crsmconfig'),
   },
 
-  utils: (import './utils.libsonnet'),
+  utils: utils,
 }

--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -361,19 +361,17 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   '#withServiceAccountMetrics':: d.fn(
     |||
       `withServiceAccountMetrics` enables scraping [ServiceAccount metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/auth/serviceaccount-metrics.md).
-
-      `annotationsAllowList` and `labelsAllowList` is only applied along with respective `metrics`.
     |||,
     args=[
       d.arg('metrics', d.T.array, default=['kube_serviceaccount_info']),
-      d.arg('annotationsAllowList', d.T.array, default=['*']),
-      d.arg('labelsAllowList', d.T.array, default=['*']),
+      d.arg('annotationsAllowList', d.T.array, default=[]),
+      d.arg('labelsAllowList', d.T.array, default=[]),
     ]
   ),
   withServiceAccountMetrics(
     metrics=['kube_serviceaccount_info'],
-    annotations=['*'],
-    labels=['*'],
+    annotationsAllowList=[],
+    labelsAllowList=[],
   )::
     self.withPolicyRulesMixin(
       utils.createWatchRules([{
@@ -382,13 +380,14 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       }])
     )
     + {
+      local superconfig = super.config,
       config+:: {
         metric_opt_in_list+: {
           [metric]: {}
           for metric in metrics
         },
-        [if std.member(metrics, 'kube_serviceaccount_annotations') then 'annotations_allow_list']+: annotations,
-        [if std.member(metrics, 'kube_serviceaccount_labels') then 'labels_allow_list']+: labels,
+        [if 'annotations_allow_list' in superconfig then 'annotations_allow_list']+: annotationsAllowList,
+        [if 'labels_allow_list' in superconfig then 'labels_allow_list']+: labelsAllowList,
       },
     },
 

--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -441,6 +441,9 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       resources: ['customresourcedefinitions'],
     },
 
+    // remove `resources` from config as it is dynamic when using CRSM
+    config:: std.mergePatch(super.config, { resources: null }),
+
     policyRules:: utils.createWatchRules(definitions + [crdrule]),
 
     CRSMConfigMap:

--- a/kube-state-metrics/utils.libsonnet
+++ b/kube-state-metrics/utils.libsonnet
@@ -151,4 +151,16 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       },
     ],
   },
+
+  '#getResourcesFromRules':: d.fn(
+    '`getResourcesFromRules` returns an array of resources for the given policy rules.',
+    args=[d.arg('rules', d.T.array)],
+  ),
+  getResourcesFromRules(rules):
+    std.set(
+      std.flatMap(
+        function(rule) rule.resources,
+        rules,
+      )
+    ),
 }


### PR DESCRIPTION
This PR adds a function to scrape [ServiceAccount metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/auth/serviceaccount-metrics.md).

The function is specific to those metrics but the logic can later probably be generalized to other [optional resources](https://github.com/kubernetes/kube-state-metrics/tree/main/docs#optional-resources).
