### PR TITLE
`ksm-custom.crossplane.statusResource`: support additional conditions

### DIFF
--- a/ksm-custom/crossplane_deprecated.libsonnet
+++ b/ksm-custom/crossplane_deprecated.libsonnet
@@ -61,7 +61,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       'Synced',
     ] + additionalConditions;
 
-    local sanitisedConditionForMetricName(condition) = std.asciiLower(condition);
+    local sanitisedConditionForMetricName(condition) = std.strReplace(std.asciiLower(condition), '-', '_');
 
     resource.withGroupVersionKind(
       group,

--- a/ksm-custom/crossplane_deprecated.libsonnet
+++ b/ksm-custom/crossplane_deprecated.libsonnet
@@ -73,32 +73,32 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     })
     + resource.withMetrics(
       [
-        metric.withName('status_%s_reason' % std.asciiLower(k))
-        + metric.withHelp('Reason for status type %s' % k)
+        metric.withName('status_%s_reason' % std.asciiLower(condition))
+        + metric.withHelp('Reason for status type %s' % condition)
         + metric.each.withType('Info')
         + metric.each.info.withLabelsFromPath({
           reason: [
             'status',
             'conditions',
-            '[type=%s]' % k,
+            '[type=%s]' % condition,
             'reason',
           ],
         })
-        for k in conditions
+        for condition in conditions
       ]
       + [
-        metric.withName('status_%s' % std.asciiLower(k))
-        + metric.withHelp('Status conditions for type %s' % k)
+        metric.withName('status_%s' % std.asciiLower(condition))
+        + metric.withHelp('Status conditions for type %s' % condition)
         + metric.each.withType('StateSet')
         + metric.each.stateSet.withLabelName('status')
         + metric.each.stateSet.withPath([
           'status',
           'conditions',
-          '[type=%s]' % k,
+          '[type=%s]' % condition,
           'status',
         ])
         + metric.each.stateSet.withList(status)
-        for k in conditions
+        for condition in conditions
       ]
     ),
 

--- a/ksm-custom/crossplane_deprecated.libsonnet
+++ b/ksm-custom/crossplane_deprecated.libsonnet
@@ -61,6 +61,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       'Synced',
     ] + additionalConditions;
 
+    local sanitisedConditionForMetricName(condition) = std.asciiLower(condition);
+
     resource.withGroupVersionKind(
       group,
       version,
@@ -73,7 +75,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     })
     + resource.withMetrics(
       [
-        metric.withName('status_%s_reason' % std.asciiLower(condition))
+        metric.withName('status_%s_reason' % sanitisedConditionForMetricName(condition))
         + metric.withHelp('Reason for status type %s' % condition)
         + metric.each.withType('Info')
         + metric.each.info.withLabelsFromPath({
@@ -87,7 +89,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         for condition in conditions
       ]
       + [
-        metric.withName('status_%s' % std.asciiLower(condition))
+        metric.withName('status_%s' % sanitisedConditionForMetricName(condition))
         + metric.withHelp('Status conditions for type %s' % condition)
         + metric.each.withType('StateSet')
         + metric.each.stateSet.withLabelName('status')

--- a/ksm-custom/crossplane_deprecated.libsonnet
+++ b/ksm-custom/crossplane_deprecated.libsonnet
@@ -44,9 +44,10 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       d.arg('group', d.T.string),
       d.arg('version', d.T.string),
       d.arg('kind', d.T.string),
+      d.arg('additionalConditions', d.T.array(d.T.string)),
     ],
   ),
-  statusResource(group, version, kind):
+  statusResource(group, version, kind, additionalConditions=[]):
     local resource = ksmCustom.spec.resources;
     local metric = ksmCustom.spec.resources.metrics;
 
@@ -58,7 +59,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     local conditions = [
       'Ready',
       'Synced',
-    ];
+    ] + additionalConditions;
 
     resource.withGroupVersionKind(
       group,


### PR DESCRIPTION
Updates `ksm-custom.crossplane.statusResource` to support generating metrics for additional conditions, while keeping backwards compatibility for existent callers of the library.