### PR TITLE
Update alert refs for crossplane lib

### DIFF
--- a/ksm-custom/crossplane.libsonnet
+++ b/ksm-custom/crossplane.libsonnet
@@ -102,10 +102,10 @@ local resource = ksmCustom.spec.resources;
               metricNamePrefix,
               [
                 // Differentiate between reasons as Create/Delete operations may take a while
-                root.alerts.claimNotReadyAlert('reason=~"(Creating|Deleting)"', '1h'),
-                root.alerts.claimNotReadyAlert('reason!~"(Creating|Deleting)"', '15m'),
+                root.stateMetrics.alerts.claim.claimNotReadyAlert('reason=~"(Creating|Deleting)"', '1h'),
+                root.stateMetrics.alerts.claim.claimNotReadyAlert('reason!~"(Creating|Deleting)"', '15m'),
 
-                root.alerts.claimNotSyncedAlert('15m'),
+                root.stateMetrics.alerts.claim.claimNotSyncedAlert('15m'),
               ]
             ),
           ]),


### PR DESCRIPTION
**Changes in this PR**
- Updates the alert references in the new `crossplane.libsonnet` to the proper new alerts

**Background**
- In https://github.com/grafana/deployment_tools/pull/239611 we vendored the new version of the crossplane metrics library. And in https://github.com/grafana/deployment_tools/pull/234184 we updated the alerts. 
- However, the [resulting](https://github.com/grafana/kube-manifests/compare/master...pr-234184#diff-bcdd80b798b28c8c69649088cb6a9cc590145e68ed0547b91c327d1f8b970c11L11) `kube-state-manifests` show that the alert uses the deprecated version of the metric, effectively breaking the alert.
- This change was tested [here](https://github.com/grafana/deployment_tools/pull/251651) and the resulting [manifests](https://github.com/grafana/kube-manifests/compare/master...pr-251651) confirm the proper new metric `crossplane_condition_status` is used instead of the deprecated `crossplane_status_ready` and `crossplane_status_synced`

**Issue Ref**
- https://github.com/grafana/deployment_tools/issues/241486