### PR TITLE
Fix - properly display type in message

### DIFF
--- a/ksm-custom/main.libsonnet
+++ b/ksm-custom/main.libsonnet
@@ -185,8 +185,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         + prometheusRules.rule.withFor('15m')
         + prometheusRules.rule.withAnnotations({
           message: |||
-            {{$labels.customresource_kind}} resource {{$labels.name}} is not {{$labels.type}} with reason {{$labels.reason}}.
-          |||,
+            {{$labels.customresource_kind}} resource {{$labels.name}} is not %s with reason {{$labels.reason}}.
+          ||| % type,
         }),
 
       '#withSeverity':: d.fn(


### PR DESCRIPTION
**Changes in this PR**
- Current alerts do not display the `type` attribute. This PR updates the templating to properly display it

<img width="522" alt="image" src="https://github.com/user-attachments/assets/525c98bc-46e0-4f93-8a10-dd5156fd7e19" />

**Background**
- Message currently shows `resource is not ... with reason`