### PR TITLE
[kube-state-metrics] Support watching endpointslices

### DIFF
--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -313,6 +313,10 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         ],
       },
       {
+        group: 'discovery.k8s.io',
+        resources: ['endpointslices'],
+      },
+      {
         group: 'autoscaling',
         resources: ['horizontalpodautoscalers'],
       },


### PR DESCRIPTION
**Changes in this PR**
- We've upgraded ksm to `v2.18.0` and are getting errors listing `endpointslices`. The release [notes](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.18.0) for this new version show:
> endpointslices are now part of the default resources exposed as metrics. endpoints is deprecated and needs to be manually activated through the --resources flag. See https://github.com/kubernetes/kube-state-metrics/pull/2659 for more details.
- This PR allows `ksm` to watch and list those resources

**Issue Ref**
- https://github.com/grafana/deployment_tools/issues/458772